### PR TITLE
Added changing to the directory of the FtcRobotController folder

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/usr/lib/android-sdk

--- a/modules/run.js
+++ b/modules/run.js
@@ -4,8 +4,10 @@ const path = require('path')
 const cp = require('child_process')
 
 let runCMD = vscode.commands.registerCommand('ftc-for-vs-code.runApp', async function () {
+	var projectFolder = findProjectDir();
+
 	var terminal = null;
-	const runCommand = process.platform == 'darwin' || process.platform == 'linux' ? './gradlew installRelease' : './gradlew.bat installRelease'
+	const runCommand = process.platform == 'darwin' || process.platform == 'linux' ? './gradlew installRelease && adb shell monkey -p com.qualcomm.ftcrobotcontroller 1' : './gradlew.bat installRelease  && adb shell monkey -p com.qualcomm.ftcrobotcontroller 1'
 	if (!fs.existsSync(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'local.properties'))) {
 		const andriodSdkPath = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || await vscode.window.showInputBox({title: 'Android SDK Path', prompt: "Enter the path of your Android SDK path. On Windows, it is sometimes C://Android/", ignoreFocusOut: true})
 		const createLocalPropertiesCommand = `cd "${vscode.workspace.workspaceFolders[0].uri.path}" && echo sdk.dir=${andriodSdkPath} > local.properties`
@@ -23,7 +25,22 @@ let runCMD = vscode.commands.registerCommand('ftc-for-vs-code.runApp', async fun
 	})
 	if (terminal == null) terminal = vscode.window.createTerminal('FTC Build')
 	terminal.show()
+	terminal.sendText(`cd ${projectFolder}`)
 	terminal.sendText(runCommand)
 });
 
+function findProjectDir() {
+	console.log("It is working!");
+
+	const fileName = vscode.window.activeTextEditor?.document.fileName;
+
+	let regex = "FtcRobotController";
+	var lastChar = fileName.search(regex) + 19; // adds 19 to the first character found in the regex, FtcRobotController/ is 19 chars long
+	var newlist = fileName.substring(0, lastChar);
+	console.log(fileName.substring(0, lastChar));
+
+	console.log("done searching...");
+	return newlist;
+	
+}
 module.exports = runCMD


### PR DESCRIPTION
When the workspace root folder is not FtcRobotController, ./gradlew fails because the file does not exist. So I edited run.js to change the directory to the correct folder in order to allow for different workspace roots. 

It uses the file that is currently open in the editor, grabs the uri, then it truncates it to the correct folder. I only tested on Ubuntu 20.04, I assume it will work in Windows as well. I also added code that opens the app through adb. I guess if adb is not installed it won't work.

TL;DR
Features Added:
- directory change to correct directory (FtcRobotController) when building the app
- opens app after build through adb

Potential Problems:
- if adb is not installed 2nd part of run script will fail
- not tested on Windows